### PR TITLE
Improve debugging output when we are unable to request a challenge

### DIFF
--- a/lib/Crypt/LE.pm
+++ b/lib/Crypt/LE.pm
@@ -853,7 +853,11 @@ sub request_challenge {
                 push @{$self->{authz}}, [ $_, '' ] for @{$content->{'authorizations'}};
                 $self->{finalize} = $content->{'finalize'};
             } else {
-                return $self->_status(ERROR, "Cannot request challenges.") unless $self->{directory}->{'new-authz'};
+                unless ( $self->{directory}->{'new-authz'} ) {
+                    my $detail = $content->{'detail'};
+                    $self->_debug("Received status $status ($detail) while requesting challenge.");
+                    return $self->_status(ERROR, "Cannot request challenges.");
+                }
                 $self->_get_authz();
             }
         }


### PR DESCRIPTION
When an API rate limit is breached, you only get a generic "Cannot request challenges" error, leaving you scratching your head about what's wrong. This change improves logging in that case so you can see *which* rate limit (or other issue) you've encountered.